### PR TITLE
Fix reliance on nonportable `strtoul()` behavior

### DIFF
--- a/src/bpmailrecv.c
+++ b/src/bpmailrecv.c
@@ -66,7 +66,11 @@ int main(int argc, char **argv) {
         switch (ch) {
             case 't':
                 errno = 0;
-                unsigned long tflag = strtoul(optarg, NULL, 0);
+                char *endptr;
+                unsigned long tflag = strtoul(optarg, &endptr, 0);
+                if (optarg == endptr) {
+                    errno = EINVAL;
+                }
                 if (errno != 0) {
                     perror("strtoul()");
                     exit(EXIT_FAILURE);

--- a/src/bpmailsend.c
+++ b/src/bpmailsend.c
@@ -119,12 +119,16 @@ static int bpmailsend(void) {
 
 int main(int argc, char **argv) {
     int ch;
+    char *endptr;
     unsigned int topic_id = 25;
     while ((ch = getopt(argc, argv, "t:")) != -1) {
         switch (ch) {
             case 't':
                 errno = 0;
-                unsigned long tflag = strtoul(optarg, NULL, 0);
+                unsigned long tflag = strtoul(optarg, &endptr, 0);
+                if (optarg == endptr) {
+                    errno = EINVAL;
+                }
                 if (errno != 0) {
                     perror("strtoul()");
                     exit(EXIT_FAILURE);
@@ -147,7 +151,10 @@ int main(int argc, char **argv) {
     }
 
     errno = 0;
-    unsigned long _profile_id = strtoul(argv[0], NULL, 0);
+    unsigned long _profile_id = strtoul(argv[0], &endptr, 0);
+    if (argv[0] == endptr) {
+        errno = EINVAL;
+    }
     if (errno != 0) {
         perror("strtoul()");
         exit(EXIT_FAILURE);

--- a/test/test_bpmail.py
+++ b/test/test_bpmail.py
@@ -82,7 +82,7 @@ def test_send_missing_args():
 def test_send_profile_id_validation():
     send = run_bpmailsend(str(2**65), dest_eid, check=False)
     assert send.returncode != 0
-    assert b'strtoul(): Result too large' in send.stderr
+    assert b'strtoul()' in send.stderr
 
     send = run_bpmailsend(str(2**33), dest_eid, check=False)
     assert send.returncode != 0
@@ -90,13 +90,13 @@ def test_send_profile_id_validation():
 
     send = run_bpmailsend('blah', dest_eid, check=False)
     assert send.returncode != 0
-    assert b'strtoul(): Invalid argument' in send.stderr
+    assert b'strtoul()' in send.stderr
 
 
 def test_send_topic_id_validation():
     send = run_bpmailsend(f'-t {2**65}', check=False)
     assert send.returncode != 0
-    assert b'strtoul(): Result too large' in send.stderr
+    assert b'strtoul()' in send.stderr
 
     send = run_bpmailsend(f'-t {2**33}', check=False)
     assert send.returncode != 0
@@ -104,13 +104,13 @@ def test_send_topic_id_validation():
 
     send = run_bpmailsend('-t blah', check=False)
     assert send.returncode != 0
-    assert b'strtoul(): Invalid argument' in send.stderr
+    assert b'strtoul()' in send.stderr
 
 
 def test_recv_topic_id_validation():
     recv = run_bpmailrecv(f'-t {2**65}', check=False)
     assert recv.returncode != 0
-    assert b'strtoul(): Result too large' in recv.stderr
+    assert b'strtoul()' in recv.stderr
 
     recv = run_bpmailrecv(f'-t {2**33}', check=False)
     assert recv.returncode != 0
@@ -118,7 +118,7 @@ def test_recv_topic_id_validation():
 
     recv = run_bpmailrecv('-t blah', check=False)
     assert recv.returncode != 0
-    assert b'strtoul(): Invalid argument' in recv.stderr
+    assert b'strtoul()' in recv.stderr
 
 
 def test_recv_extra_args():


### PR DESCRIPTION
Closes #21 